### PR TITLE
Dataflow pipeline with added steps

### DIFF
--- a/census/estimator/bin/run.preprocess.cloud.sh
+++ b/census/estimator/bin/run.preprocess.cloud.sh
@@ -12,8 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Convenience script for running preprocessing jobs."""
 
+# Convenience script for running preprocessing jobs on Dataflow.
 
 BUCKET_NAME='census-example'
 PROJECT_ID=$(gcloud config list --format 'value(core.project)' 2>/dev/null)
@@ -24,7 +24,7 @@ TRAINING_DATA=gs://cloud-samples-data/ml-engine/census/data/adult.data.csv
 
 
 python run_preprocessing.py \
-  --project_name $PROJECT_ID \
+  --project_id $PROJECT_ID \
   --job_name $JOB_NAME \
   --job_dir $DATAFLOW_DIR \
   --input_data $TRAINING_DATA \

--- a/census/estimator/bin/run.preprocess.local.sh
+++ b/census/estimator/bin/run.preprocess.local.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Convenience script for running local preprocessing jobs.
+
+BUCKET_NAME='census-example'
+PROJECT_ID=$(gcloud config list --format 'value(core.project)' 2>/dev/null)
+
+JOB_NAME=preprocessing-${DATE_TIME}-${USER}
+DATAFLOW_DIR=dataflow_dir
+TRAINING_DATA=gs://cloud-samples-data/ml-engine/census/data/adult.data.csv
+
+rm -rf $DATAFLOW_DIR
+
+python run_preprocessing.py \
+  --project_id $PROJECT_ID \
+  --job_name $JOB_NAME \
+  --job_dir $DATAFLOW_DIR \
+  --input_data $TRAINING_DATA

--- a/census/estimator/constants/constants.py
+++ b/census/estimator/constants/constants.py
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Constants shared by preprocessing and modeling scripts."""
+
+
+CSV_ORDERED_COLUMNS = [
+    'age', 'workclass', 'education', 'education_num',
+    'marital_status', 'occupation', 'relationship', 'race', 'gender',
+    'capital_gain', 'capital_loss', 'hours_per_week',
+    'native_country', 'income_bracket']

--- a/census/estimator/preprocessing/preprocess.py
+++ b/census/estimator/preprocessing/preprocess.py
@@ -14,21 +14,76 @@
 """Defines the Beam pipeline to preprocess the data."""
 
 import csv
+import os
+import random
 
 import apache_beam as beam
 import tensorflow as tf
 
+from constants import constants
+
 
 class CsvFileSource(beam.io.filebasedsource.FileBasedSource):
+  """Beam source for CSV files."""
+
+  def __init__(self, file_pattern, column_names):
+    self._column_names = column_names
+    super(self.__class__, self).__init__(file_pattern)
 
   def read_records(self, file_name, unused_range_tracker):
-    self._file = tf.gfile.GFile(file_name)
+    self._file = self.open_file(file_name)
     reader = csv.reader(self._file)
     for rec in reader:
-      yield rec
+      res = {key: val for key, val in zip(self._column_names, rec)}
+      yield res
 
 
-def run(p, input_path):
+def split_data(examples, train_fraction):
+  """Splits the data into train/eval."""
+
+  def partition_fn(data, n_partition):
+    random_value = random.random()
+    if random_value < train_fraction:
+      return 0
+    return 1
+
+  examples_split = (examples
+                    | "SplitData" >> beam.Partition(partition_fn, 2))
+  return examples_split
+
+
+class ConvertDictToCSV(beam.DoFn):
+  """Takes a dictionary and converts it to csv format."""
+
+  def __init__(self, ordered_fieldnames, separator=","):
+    self._ordered_fieldnames = ordered_fieldnames
+    self._separator = separator
+
+  def process(self, input_dict):
+    value_list = []
+    for field in self._ordered_fieldnames:
+      value_list.append(input_dict[field])
+    yield self._separator.join(value_list)
+
+
+def run(p, input_path, output_directory, train_fraction=0.8):
+  """Runs the pipeline."""
 
   raw_data = (p
-              | 'ReadTrainData' >> beam.io.Read(CsvFileSource(input_path)))
+      | "ReadTrainData" >> beam.io.Read(CsvFileSource(
+          input_path,
+          column_names=constants.CSV_ORDERED_COLUMNS)))
+  train_data, eval_data = split_data(raw_data, train_fraction)
+
+  _ = (train_data
+      | "PrepareCSV_train" >> beam.ParDo(
+          ConvertDictToCSV(ordered_fieldnames=constants.CSV_ORDERED_COLUMNS))
+      | "Write_train" >> beam.io.WriteToText(
+          os.path.join(output_directory, "output_data", "train"),
+          file_name_suffix=".csv"))
+  _ = (eval_data 
+      | "PrepareCSV_eval" >> beam.ParDo(
+          ConvertDictToCSV(ordered_fieldnames=constants.CSV_ORDERED_COLUMNS))
+      | "Write_eval" >> beam.io.WriteToText(
+          os.path.join(output_directory, "output_data", "eval"),
+          file_name_suffix=".csv"))

--- a/census/estimator/run_preprocessing.py
+++ b/census/estimator/run_preprocessing.py
@@ -90,14 +90,16 @@ def main():
         'max_num_workers': int(config.get('max_num_workers')),
         'staging_location': os.path.join(args.job_dir, 'staging'),
         'temp_location': os.path.join(args.job_dir, 'tmp'),
-        'region': config.get('region')
+        'region': config.get('region'),
+        'setup_file': os.path.abspath(os.path.join(
+            os.path.dirname(__file__), 'setup.py')),
         })
   pipeline_options = beam.pipeline.PipelineOptions(flags=[], **options)
   _set_logging(config.get('log_level'))
 
   with beam.Pipeline(
       config.get('runner'), options=pipeline_options) as pipeline:
-    preprocess.run(pipeline, args.input_data)
+    preprocess.run(pipeline, args.input_data, args.job_dir)
 
 
 if __name__ == '__main__':

--- a/census/estimator/setup.py
+++ b/census/estimator/setup.py
@@ -1,0 +1,29 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+'''Dependencies for Dataflow workers.'''
+
+from setuptools import setup, find_packages
+import os
+
+NAME = 'preprocessing'
+VERSION = '1.0'
+REQUIRED_PACKAGES = ['tensorflow-transform==0.9.0']
+
+
+setup(
+    name=NAME,
+    version=VERSION,
+    packages=find_packages(),
+    install_requires=REQUIRED_PACKAGES,    
+    )


### PR DESCRIPTION
Added these steps to the pipeline:
- Parsing the csv. Requires to use a folder constants.py (which will be shared with TF).
- Splitting the data into train/eval: f I am correct, the current TF code uses the test set as validation. even if it is not an important change, it is just to illustrate CMLE functionalities.
- Outputs back to csv.

Next steps will be:
- Updating README
- Integrating with TF.